### PR TITLE
Included installation of extension dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,31 @@ It's not yet ready to be released on the Chrome Web Store, but if you want to ch
         git clone https://github.com/cartant/rxjs-spy-devtools.git
         cd rxjs-spy-devtools
 
-2. Build the panel:
+2. Install extension dependencies (for rxjs-spy devtools)
 
-        cd panel
+        cd extension
+        yarn install
+
+3. Build the panel:
+
+        cd ../panel
         yarn install
         yarn build:p
 
-3. Build the extension:
+4. Build the extension:
 
         cd ../extension
-        yarn install
         yarn build:p
 
-4. Install the extension:
+5. Install the extension:
 
     * In Chrome, navigate to "chrome://extensions".
     * Click the "Load unpacked extension..." button.
     * Navigate to the `rxjs-spy-devtools/extension/dist` directory and click OK.
 
-5. If you open the DevTools, you should have an "RxJS" entry in the tab panel. (You might have to click the `>>` button to see it.)
+6. If you open the DevTools, you should have an "RxJS" entry in the tab panel. (You might have to click the `>>` button to see it.)
 
-6. If you navigate to a page in which a spy has been created (using at least version 6.0.0 of `rxjs-spy`), you should see a list of observables (filterable on tag and type) in the "RxJS" panel. The simplest way to do this is to run the following command from within the `extension` directory:
+7. If you navigate to a page in which a spy has been created (using at least version 6.0.0 of `rxjs-spy`), you should see a list of observables (filterable on tag and type) in the "RxJS" panel. The simplest way to do this is to run the following command from within the `extension` directory:
 
         yarn harness
 


### PR DESCRIPTION
The _panel_ module requires a dependency that must be installed in the _extension_ module first, as seen in `panel/tsconfig.json`:

```
"paths": {
      "@devtools/*": [
        "../../extension/node_modules/rxjs-spy/devtools/*"
      ]
    },
```
I adapted the README.md to guide users to `yarn install` the _extension_ module firs.t
